### PR TITLE
Context bugfix and method preprocessors

### DIFF
--- a/module/src/main/java/com/annimon/tgbotsmodule/commands/CommandRegistry.java
+++ b/module/src/main/java/com/annimon/tgbotsmodule/commands/CommandRegistry.java
@@ -93,7 +93,7 @@ public class CommandRegistry implements UpdateHandler {
     }
 
     public CommandRegistry splitCallbackCommandByPattern(@NotNull String pattern) {
-        this.callbackCommandSplitPattern = Objects.requireNonNull(pattern);;
+        this.callbackCommandSplitPattern = Objects.requireNonNull(pattern);
         return this;
     }
 
@@ -136,8 +136,6 @@ public class CommandRegistry implements UpdateHandler {
         final MessageContext context = new MessageContextBuilder()
                 .setSender(handler)
                 .setUpdate(update)
-                .setUser(message.getFrom())
-                .setChatId(message.getChatId())
                 .setText(args.length >= 2 ? args[1] : "")
                 .createMessageContext();
         for (TextCommand cmd : commands) {
@@ -156,8 +154,6 @@ public class CommandRegistry implements UpdateHandler {
                 .map(e -> Map.entry(e.getKey(), new MessageContextBuilder()
                         .setSender(handler)
                         .setUpdate(update)
-                        .setUser(message.getFrom())
-                        .setChatId(message.getChatId())
                         .setText(text)
                         .createRegexContext(e.getValue())))
                 .peek(e -> e.getKey().accept(e.getValue()))
@@ -180,7 +176,6 @@ public class CommandRegistry implements UpdateHandler {
         final CallbackQueryContext context = new CallbackQueryContextBuilder()
                 .setSender(handler)
                 .setUpdate(update)
-                .setUser(query.getFrom())
                 .setArgumentsAsString(args.length >= 2 ? args[1] : "")
                 .createContext();
         for (CallbackQueryCommand cmd : commands) {

--- a/module/src/main/java/com/annimon/tgbotsmodule/commands/context/CallbackQueryContext.java
+++ b/module/src/main/java/com/annimon/tgbotsmodule/commands/context/CallbackQueryContext.java
@@ -13,13 +13,8 @@ import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMa
 
 public class CallbackQueryContext extends Context {
 
-    private String argumentsAsString;
-    private String[] arguments;
-    private int argumentsLimit;
-
     CallbackQueryContext(CommonAbsSender sender, Update update, User user, String text) {
-        super(sender, update, user);
-        this.argumentsAsString = text;
+        super(sender, update, user, text);
     }
 
     public @NotNull CallbackQuery callbackQuery() {
@@ -38,59 +33,8 @@ public class CallbackQueryContext extends Context {
         return callbackQuery().getData();
     }
 
-    public String argumentsAsString() {
-        return argumentsAsString;
-    }
-
     public String gameShortName() {
         return callbackQuery().getGameShortName();
-    }
-
-    public @NotNull String argument(int index) {
-        return argument(index, "");
-    }
-
-    public @NotNull String argument(int index, @NotNull String defaultValue) {
-        lazyCreateArguments();
-        if (index < 0 || index >= argumentsLength()) {
-            return defaultValue;
-        }
-        final var result = arguments[index];
-        if (result.isEmpty()) {
-            return defaultValue;
-        }
-        return result;
-    }
-
-    public @NotNull String[] arguments() {
-        lazyCreateArguments();
-        return arguments;
-    }
-
-    public int argumentsLength() {
-        return arguments().length;
-    }
-
-    public int argumentsLimit() {
-        return argumentsLimit;
-    }
-
-    private void createArguments() {
-        arguments = argumentsAsString.split("\\s+", argumentsLimit);
-    }
-
-    private void lazyCreateArguments() {
-        if (arguments == null) {
-            createArguments();
-        }
-    }
-
-    public void setArgumentsLimit(int argumentsLimit) {
-        if (argumentsLimit == this.argumentsLimit)
-            return;
-
-        this.argumentsLimit = argumentsLimit;
-        createArguments();
     }
 
     public @NotNull AnswerCallbackQueryMethod answer(String text) {

--- a/module/src/main/java/com/annimon/tgbotsmodule/commands/context/CallbackQueryContext.java
+++ b/module/src/main/java/com/annimon/tgbotsmodule/commands/context/CallbackQueryContext.java
@@ -8,13 +8,12 @@ import org.jetbrains.annotations.NotNull;
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.Update;
-import org.telegram.telegrambots.meta.api.objects.User;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
 
 public class CallbackQueryContext extends Context {
 
-    CallbackQueryContext(CommonAbsSender sender, Update update, User user, String text) {
-        super(sender, update, user, text);
+    public CallbackQueryContext(CommonAbsSender sender, Update update, String text) {
+        super(sender, update, update.getCallbackQuery().getFrom(), text);
     }
 
     public @NotNull CallbackQuery callbackQuery() {

--- a/module/src/main/java/com/annimon/tgbotsmodule/commands/context/CallbackQueryContextBuilder.java
+++ b/module/src/main/java/com/annimon/tgbotsmodule/commands/context/CallbackQueryContextBuilder.java
@@ -2,13 +2,11 @@ package com.annimon.tgbotsmodule.commands.context;
 
 import com.annimon.tgbotsmodule.services.CommonAbsSender;
 import org.telegram.telegrambots.meta.api.objects.Update;
-import org.telegram.telegrambots.meta.api.objects.User;
 
 public class CallbackQueryContextBuilder {
 
     private CommonAbsSender sender;
     private Update update;
-    private User user;
     private String argumentsAsString;
 
     public CallbackQueryContextBuilder setSender(CommonAbsSender sender) {
@@ -21,17 +19,12 @@ public class CallbackQueryContextBuilder {
         return this;
     }
 
-    public CallbackQueryContextBuilder setUser(User user) {
-        this.user = user;
-        return this;
-    }
-
     public CallbackQueryContextBuilder setArgumentsAsString(String text) {
         this.argumentsAsString = text;
         return this;
     }
 
     public CallbackQueryContext createContext() {
-        return new CallbackQueryContext(sender, update, user, argumentsAsString);
+        return new CallbackQueryContext(sender, update, argumentsAsString);
     }
 }

--- a/module/src/main/java/com/annimon/tgbotsmodule/commands/context/Context.java
+++ b/module/src/main/java/com/annimon/tgbotsmodule/commands/context/Context.java
@@ -75,6 +75,4 @@ public class Context {
         this.argumentsLimit = argumentsLimit;
         createArguments();
     }
-
-
 }

--- a/module/src/main/java/com/annimon/tgbotsmodule/commands/context/Context.java
+++ b/module/src/main/java/com/annimon/tgbotsmodule/commands/context/Context.java
@@ -59,7 +59,7 @@ public class Context {
     }
 
     protected void createArguments() {
-        arguments = text.isBlank() ? new String[]{} : text.split("\\s+", argumentsLimit);
+        arguments = text.isBlank() ? new String[0] : text.split("\\s+", argumentsLimit);
     }
 
     private void lazyCreateArguments() {

--- a/module/src/main/java/com/annimon/tgbotsmodule/commands/context/Context.java
+++ b/module/src/main/java/com/annimon/tgbotsmodule/commands/context/Context.java
@@ -10,11 +10,16 @@ public class Context {
     public final CommonAbsSender sender;
     protected final Update update;
     protected final User user;
+    protected final String text;
+    protected String[] arguments;
+    protected int argumentsLimit;
 
-    Context(CommonAbsSender sender, Update update, User user) {
+    Context(CommonAbsSender sender, Update update, User user, String text) {
         this.sender = sender;
         this.update = update;
         this.user = user;
+        this.text = text;
+        this.argumentsLimit = 0;
     }
 
     public @NotNull Update update() {
@@ -24,4 +29,52 @@ public class Context {
     public @NotNull User user() {
         return user;
     }
+
+    public String getText() {
+        return text;
+    }
+
+    public @NotNull String argument(int index) {
+        return argument(index, "");
+    }
+
+    public @NotNull String argument(int index, @NotNull String defaultValue) {
+        if (index < 0 || index >= argumentsLength()) {
+            return defaultValue;
+        }
+        return arguments[index];
+    }
+
+    public @NotNull String[] arguments() {
+        lazyCreateArguments();
+        return arguments;
+    }
+
+    public int argumentsLength() {
+        return arguments().length;
+    }
+
+    public int argumentsLimit() {
+        return argumentsLimit;
+    }
+
+    protected void createArguments() {
+        arguments = text.isBlank() ? new String[]{} : text.split("\\s+", argumentsLimit);
+    }
+
+    private void lazyCreateArguments() {
+        if (arguments == null) {
+            createArguments();
+        }
+    }
+
+    public void setArgumentsLimit(int argumentsLimit) {
+        if (argumentsLimit == this.argumentsLimit)
+            return;
+
+        this.argumentsLimit = argumentsLimit;
+        createArguments();
+    }
+
+
 }

--- a/module/src/main/java/com/annimon/tgbotsmodule/commands/context/MessageContext.java
+++ b/module/src/main/java/com/annimon/tgbotsmodule/commands/context/MessageContext.java
@@ -9,15 +9,11 @@ import com.annimon.tgbotsmodule.services.CommonAbsSender;
 import org.jetbrains.annotations.NotNull;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.Update;
-import org.telegram.telegrambots.meta.api.objects.User;
 
 public class MessageContext extends Context {
 
-    private final Long chatId;
-
-    MessageContext(CommonAbsSender sender, Update update, User user, Long chatId, String text) {
-        super(sender, update, user, text);
-        this.chatId = chatId;
+    public MessageContext(CommonAbsSender sender, Update update, String text) {
+        super(sender, update, update.getMessage().getFrom(), text);
         this.argumentsLimit = 0;
     }
 
@@ -30,7 +26,7 @@ public class MessageContext extends Context {
     }
 
     public @NotNull Long chatId() {
-        return chatId;
+        return message().getChatId();
     }
 
     public @NotNull String text() {
@@ -38,7 +34,7 @@ public class MessageContext extends Context {
     }
 
     public @NotNull SendAnimationMethod replyWithAnimation() {
-        return Methods.sendAnimation(chatId);
+        return Methods.sendAnimation(chatId());
     }
 
     public @NotNull SendAnimationMethod replyToMessageWithAnimation() {
@@ -48,7 +44,7 @@ public class MessageContext extends Context {
     }
 
     public @NotNull SendAudioMethod replyWithAudio() {
-        return Methods.sendAudio(chatId);
+        return Methods.sendAudio(chatId());
     }
 
     public @NotNull SendAudioMethod replyToMessageWithAudio() {
@@ -58,7 +54,7 @@ public class MessageContext extends Context {
     }
 
     public @NotNull SendContactMethod replyWithContact() {
-        return Methods.sendContact().setChatId(chatId);
+        return Methods.sendContact().setChatId(chatId());
     }
 
     public @NotNull SendContactMethod replyToMessageWithContact() {
@@ -68,7 +64,7 @@ public class MessageContext extends Context {
     }
 
     public @NotNull SendDiceMethod replyWithDice() {
-        return Methods.sendDice(chatId);
+        return Methods.sendDice(chatId());
     }
 
     public @NotNull SendDiceMethod replyToMessageWithDice() {
@@ -78,7 +74,7 @@ public class MessageContext extends Context {
     }
 
     public @NotNull SendDocumentMethod replyWithDocument() {
-        return Methods.sendDocument(chatId);
+        return Methods.sendDocument(chatId());
     }
 
     public @NotNull SendDocumentMethod replyToMessageWithDocument() {
@@ -88,7 +84,7 @@ public class MessageContext extends Context {
     }
 
     public @NotNull SendGameMethod replyWithGame() {
-        return Methods.Games.sendGame().setChatId(chatId);
+        return Methods.Games.sendGame().setChatId(chatId());
     }
 
     public @NotNull SendGameMethod replyToMessageWithGame() {
@@ -98,7 +94,7 @@ public class MessageContext extends Context {
     }
 
     public @NotNull SendInvoiceMethod replyWithInvoice() {
-        return Methods.Payments.sendInvoice(chatId);
+        return Methods.Payments.sendInvoice(chatId());
     }
 
     public @NotNull SendInvoiceMethod replyToMessageWithInvoice() {
@@ -108,7 +104,7 @@ public class MessageContext extends Context {
     }
 
     public @NotNull SendLocationMethod replyWithLocation() {
-        return Methods.sendLocation().setChatId(chatId);
+        return Methods.sendLocation().setChatId(chatId());
     }
 
     public @NotNull SendLocationMethod replyToMessageWithLocation() {
@@ -118,7 +114,7 @@ public class MessageContext extends Context {
     }
 
     public @NotNull SendMediaGroupMethod replyWithMediaGroup() {
-        return Methods.sendMediaGroup().setChatId(chatId);
+        return Methods.sendMediaGroup().setChatId(chatId());
     }
 
     public @NotNull SendMediaGroupMethod replyToMessageWithMediaGroup() {
@@ -128,11 +124,11 @@ public class MessageContext extends Context {
     }
 
     public @NotNull SendMessageMethod reply() {
-        return Methods.sendMessage().setChatId(chatId);
+        return Methods.sendMessage().setChatId(chatId());
     }
 
     public @NotNull SendMessageMethod reply(@NotNull String text) {
-        return Methods.sendMessage(chatId, text);
+        return Methods.sendMessage(chatId(), text);
     }
 
     public @NotNull SendMessageMethod replyToMessage() {
@@ -148,7 +144,7 @@ public class MessageContext extends Context {
     }
 
     public @NotNull SendPhotoMethod replyWithPhoto() {
-        return Methods.sendPhoto(chatId);
+        return Methods.sendPhoto(chatId());
     }
 
     public @NotNull SendPhotoMethod replyToMessageWithPhoto() {
@@ -158,7 +154,7 @@ public class MessageContext extends Context {
     }
 
     public @NotNull SendStickerMethod replyWithSticker() {
-        return Methods.Stickers.sendSticker(chatId);
+        return Methods.Stickers.sendSticker(chatId());
     }
 
     public @NotNull SendStickerMethod replyToMessageWithSticker() {
@@ -168,7 +164,7 @@ public class MessageContext extends Context {
     }
 
     public @NotNull SendVenueMethod replyWithVenue() {
-        return Methods.sendVenue().setChatId(chatId);
+        return Methods.sendVenue().setChatId(chatId());
     }
 
     public @NotNull SendVenueMethod replyToMessageWithVenue() {
@@ -178,7 +174,7 @@ public class MessageContext extends Context {
     }
 
     public @NotNull SendVideoMethod replyWithVideo() {
-        return Methods.sendVideo(chatId);
+        return Methods.sendVideo(chatId());
     }
 
     public @NotNull SendVideoMethod replyToMessageWithVideo() {
@@ -188,7 +184,7 @@ public class MessageContext extends Context {
     }
 
     public @NotNull SendVideoNoteMethod replyWithVideoNote() {
-        return Methods.sendVideoNote(chatId);
+        return Methods.sendVideoNote(chatId());
     }
 
     public @NotNull SendVideoNoteMethod replyToMessageWithVideoNote() {
@@ -198,7 +194,7 @@ public class MessageContext extends Context {
     }
 
     public @NotNull SendVoiceMethod replyWithVoice() {
-        return Methods.sendVoice(chatId);
+        return Methods.sendVoice(chatId());
     }
 
     public @NotNull SendVoiceMethod replyToMessageWithVoice() {
@@ -209,14 +205,14 @@ public class MessageContext extends Context {
 
 
     public @NotNull DeleteMessageMethod deleteMessage() {
-        return Methods.deleteMessage(chatId, messageId());
+        return Methods.deleteMessage(chatId(), messageId());
     }
 
     public @NotNull ForwardMessageMethod forwardMessageTo(long toChatId) {
-        return Methods.forwardMessage(toChatId, chatId, messageId());
+        return Methods.forwardMessage(toChatId, chatId(), messageId());
     }
 
     public @NotNull CopyMessageMethod copyMessageTo(long toChatId) {
-        return Methods.copyMessage(toChatId, chatId, messageId());
+        return Methods.copyMessage(toChatId, chatId(), messageId());
     }
 }

--- a/module/src/main/java/com/annimon/tgbotsmodule/commands/context/MessageContext.java
+++ b/module/src/main/java/com/annimon/tgbotsmodule/commands/context/MessageContext.java
@@ -12,8 +12,11 @@ import org.telegram.telegrambots.meta.api.objects.Update;
 
 public class MessageContext extends Context {
 
+    private final Long chatId;
+
     public MessageContext(CommonAbsSender sender, Update update, String text) {
         super(sender, update, update.getMessage().getFrom(), text);
+        this.chatId = update.getMessage().getChatId();
         this.argumentsLimit = 0;
     }
 
@@ -26,7 +29,7 @@ public class MessageContext extends Context {
     }
 
     public @NotNull Long chatId() {
-        return message().getChatId();
+        return chatId;
     }
 
     public @NotNull String text() {

--- a/module/src/main/java/com/annimon/tgbotsmodule/commands/context/MessageContext.java
+++ b/module/src/main/java/com/annimon/tgbotsmodule/commands/context/MessageContext.java
@@ -14,14 +14,10 @@ import org.telegram.telegrambots.meta.api.objects.User;
 public class MessageContext extends Context {
 
     private final Long chatId;
-    private final String text;
-    private String[] arguments;
-    private int argumentsLimit;
 
     MessageContext(CommonAbsSender sender, Update update, User user, Long chatId, String text) {
-        super(sender, update, user);
+        super(sender, update, user, text);
         this.chatId = chatId;
-        this.text = text;
         this.argumentsLimit = 0;
     }
 
@@ -30,7 +26,7 @@ public class MessageContext extends Context {
     }
 
     public @NotNull Integer messageId() {
-        return update.getMessage().getMessageId();
+        return message().getMessageId();
     }
 
     public @NotNull Long chatId() {
@@ -39,53 +35,6 @@ public class MessageContext extends Context {
 
     public @NotNull String text() {
         return text;
-    }
-
-    public @NotNull String argument(int index) {
-        return argument(index, "");
-    }
-
-    public @NotNull String argument(int index, @NotNull String defaultValue) {
-        lazyCreateArguments();
-        if (index < 0 || index >= argumentsLength()) {
-            return defaultValue;
-        }
-        final var result = arguments[index];
-        if (result.isEmpty()) {
-            return defaultValue;
-        }
-        return result;
-    }
-
-    public @NotNull String[] arguments() {
-        lazyCreateArguments();
-        return arguments;
-    }
-
-    public int argumentsLength() {
-        return arguments().length;
-    }
-
-    public int argumentsLimit() {
-        return argumentsLimit;
-    }
-
-    private void createArguments() {
-        arguments = text.split("\\s+", argumentsLimit);
-    }
-
-    private void lazyCreateArguments() {
-        if (arguments == null) {
-            createArguments();
-        }
-    }
-
-    public void setArgumentsLimit(int argumentsLimit) {
-        if (argumentsLimit == this.argumentsLimit)
-            return;
-
-        this.argumentsLimit = argumentsLimit;
-        createArguments();
     }
 
     public @NotNull SendAnimationMethod replyWithAnimation() {

--- a/module/src/main/java/com/annimon/tgbotsmodule/commands/context/MessageContextBuilder.java
+++ b/module/src/main/java/com/annimon/tgbotsmodule/commands/context/MessageContextBuilder.java
@@ -8,8 +8,6 @@ import org.telegram.telegrambots.meta.api.objects.User;
 public class MessageContextBuilder {
     private CommonAbsSender sender;
     private Update update;
-    private User user;
-    private Long chatId;
     private String text;
 
     public MessageContextBuilder setSender(CommonAbsSender sender) {
@@ -22,23 +20,13 @@ public class MessageContextBuilder {
         return this;
     }
 
-    public MessageContextBuilder setUser(User user) {
-        this.user = user;
-        return this;
-    }
-
-    public MessageContextBuilder setChatId(Long chatId) {
-        this.chatId = chatId;
-        return this;
-    }
-
     public MessageContextBuilder setText(String text) {
         this.text = text;
         return this;
     }
 
     public MessageContext createMessageContext() {
-        return new MessageContext(sender, update, user, chatId, text);
+        return new MessageContext(sender, update, text);
     }
 
     public RegexMessageContext createRegexContext(Matcher matcher) {

--- a/module/src/main/java/com/annimon/tgbotsmodule/commands/context/RegexMessageContext.java
+++ b/module/src/main/java/com/annimon/tgbotsmodule/commands/context/RegexMessageContext.java
@@ -6,8 +6,8 @@ public class RegexMessageContext extends MessageContext {
 
     protected final Matcher matcher;
 
-    RegexMessageContext(MessageContext m, Matcher matcher) {
-        super(m.sender, m.update, m.user, m.chatId(), m.text());
+    public RegexMessageContext(MessageContext m, Matcher matcher) {
+        super(m.sender, m.update, m.text());
         this.matcher = matcher;
     }
 

--- a/module/src/main/java/com/annimon/tgbotsmodule/services/CommonAbsSender.java
+++ b/module/src/main/java/com/annimon/tgbotsmodule/services/CommonAbsSender.java
@@ -485,9 +485,9 @@ public abstract class CommonAbsSender extends DefaultAbsSender {
      * as {@code TelegramApiException} error callback and
      * suppresses all other callbacks
      *
-     * @param method api method
-     * @param <T>    the type of the result
-     * @param <M>    the type of the api method
+     * @param method  api method
+     * @param <T> the type of the result
+     * @param <M> the type of the api method
      * @see #callAsync(BotApiMethod, Consumer, Consumer, Consumer)
      * @see #handleTelegramApiException(TelegramApiException)
      */
@@ -498,15 +498,15 @@ public abstract class CommonAbsSender extends DefaultAbsSender {
 
     /**
      * {@code callAsyncWithCallback} implementation on lambda Consumers.
-     * <p>
+     *
      * Uses {@code handleTelegramApiException} method
      * as {@code TelegramApiException} error callback and
      * suppresses exception callback
      *
-     * @param method           api method
-     * @param responseConsumer response callback
-     * @param <T>              the type of the result
-     * @param <M>              the type of the api method
+     * @param method  api method
+     * @param responseConsumer  response callback
+     * @param <T> the type of the result
+     * @param <M> the type of the api method
      * @see #callAsync(BotApiMethod, Consumer, Consumer, Consumer)
      * @see #handleTelegramApiException(TelegramApiException)
      */
@@ -518,15 +518,15 @@ public abstract class CommonAbsSender extends DefaultAbsSender {
 
     /**
      * {@code callAsyncWithCallback} implementation on lambda Consumers.
-     * <p>
+     *
      * Uses {@code handleTelegramApiException} method
      * as {@code TelegramApiException} error callback
      *
-     * @param method            api method
+     * @param method  api method
      * @param responseConsumer  response callback
-     * @param exceptionConsumer exception callback
-     * @param <T>               the type of the result
-     * @param <M>               the type of the api method
+     * @param exceptionConsumer  exception callback
+     * @param <T> the type of the result
+     * @param <M> the type of the api method
      * @see #callAsync(BotApiMethod, Consumer, Consumer, Consumer)
      * @see #handleTelegramApiException(TelegramApiException)
      */
@@ -541,12 +541,12 @@ public abstract class CommonAbsSender extends DefaultAbsSender {
     /**
      * {@code callAsyncWithCallback} implementation on lambda Consumers.
      *
-     * @param method               api method
-     * @param responseConsumer     response callback
-     * @param apiExceptionConsumer {@code TelegramApiException} error callback
-     * @param exceptionConsumer    exception callback
-     * @param <T>                  the type of the result
-     * @param <M>                  the type of the api method
+     * @param method  api method
+     * @param responseConsumer  response callback
+     * @param apiExceptionConsumer  {@code TelegramApiException} error callback
+     * @param exceptionConsumer  exception callback
+     * @param <T> the type of the result
+     * @param <M> the type of the api method
      * @see #callAsyncWithCallback(BotApiMethod, SentCallback)
      */
     public <T extends Serializable, M extends BotApiMethod<T>> void callAsync(
@@ -609,10 +609,10 @@ public abstract class CommonAbsSender extends DefaultAbsSender {
 
     /**
      * Handles exceptions for {@code call} methods.
-     * <p>
+     *
      * By default logs exception as an error.
      *
-     * @param ex Exception
+     * @param ex  Exception
      */
     public void handleTelegramApiException(TelegramApiException ex) {
         log.error("telegram api exception ", ex);

--- a/testbot-kotlin/src/main/kotlin/com/annimon/testbotkt/TestBotHandler.kt
+++ b/testbot-kotlin/src/main/kotlin/com/annimon/testbotkt/TestBotHandler.kt
@@ -9,6 +9,8 @@ import com.annimon.tgbotsmodule.commands.authority.For
 import com.annimon.tgbotsmodule.commands.authority.SimpleAuthority
 import org.telegram.telegrambots.meta.api.methods.ActionType
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage
+import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageText
 import org.telegram.telegrambots.meta.api.objects.Update
 
 class TestBotHandler(private val botConfig: BotConfig) : BotHandler() {
@@ -49,6 +51,16 @@ class TestBotHandler(private val botConfig: BotConfig) : BotHandler() {
 
         // Locale
         commands.registerBundle(LocalizationBundle())
+
+        addMethodPreprocessor(SendMessage.PATH){
+            it as SendMessage
+            it.disableWebPagePreview()
+        }
+
+        addMethodPreprocessor(EditMessageText.PATH){
+            it as EditMessageText
+            it.disableWebPagePreview()
+        }
     }
 
     override fun onUpdate(update: Update): BotApiMethod<*>? {

--- a/testbot-kotlin/src/main/kotlin/com/annimon/testbotkt/TestBotHandler.kt
+++ b/testbot-kotlin/src/main/kotlin/com/annimon/testbotkt/TestBotHandler.kt
@@ -52,13 +52,11 @@ class TestBotHandler(private val botConfig: BotConfig) : BotHandler() {
         // Locale
         commands.registerBundle(LocalizationBundle())
 
-        addMethodPreprocessor(SendMessage.PATH){
-            it as SendMessage
+        addMethodPreprocessor(SendMessage::class.java) {
+            it.allowSendingWithoutReply = true
             it.disableWebPagePreview()
         }
-
-        addMethodPreprocessor(EditMessageText.PATH){
-            it as EditMessageText
+        addMethodPreprocessor(EditMessageText::class.java) {
             it.disableWebPagePreview()
         }
     }

--- a/testbot/src/main/java/com/annimon/testbot/TestBotHandler.java
+++ b/testbot/src/main/java/com/annimon/testbot/TestBotHandler.java
@@ -3,7 +3,6 @@ package com.annimon.testbot;
 import com.annimon.testbot.commands.LocalizationBundle;
 import com.annimon.tgbotsmodule.BotHandler;
 import com.annimon.tgbotsmodule.api.methods.Methods;
-import com.annimon.tgbotsmodule.api.methods.send.SendMessageMethod;
 import com.annimon.tgbotsmodule.commands.CommandRegistry;
 import com.annimon.tgbotsmodule.commands.SimpleCommand;
 import com.annimon.tgbotsmodule.commands.SimpleRegexCommand;
@@ -18,7 +17,6 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.regex.Pattern;
 import javax.imageio.ImageIO;
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.jetbrains.annotations.NotNull;
 import org.telegram.telegrambots.meta.api.methods.ActionType;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
@@ -60,15 +58,11 @@ public class TestBotHandler extends BotHandler {
         // Locale
         commands.registerBundle(new LocalizationBundle());
 
-        addMethodPreprocessor(SendMessage.PATH, m -> {
-            var sm = (SendMessage) m;
-            sm.disableWebPagePreview();
+        addMethodPreprocessor(SendMessage.class, m -> {
+            m.setAllowSendingWithoutReply(true);
+            m.disableWebPagePreview();
         });
-
-        addMethodPreprocessor(EditMessageText.PATH, m -> {
-            var emt = (EditMessageText) m;
-            emt.disableWebPagePreview();
-        });
+        addMethodPreprocessor(EditMessageText.class, EditMessageText::disableWebPagePreview);
     }
 
     @Override

--- a/testbot/src/main/java/com/annimon/testbot/TestBotHandler.java
+++ b/testbot/src/main/java/com/annimon/testbot/TestBotHandler.java
@@ -3,6 +3,7 @@ package com.annimon.testbot;
 import com.annimon.testbot.commands.LocalizationBundle;
 import com.annimon.tgbotsmodule.BotHandler;
 import com.annimon.tgbotsmodule.api.methods.Methods;
+import com.annimon.tgbotsmodule.api.methods.send.SendMessageMethod;
 import com.annimon.tgbotsmodule.commands.CommandRegistry;
 import com.annimon.tgbotsmodule.commands.SimpleCommand;
 import com.annimon.tgbotsmodule.commands.SimpleRegexCommand;
@@ -17,8 +18,13 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.regex.Pattern;
 import javax.imageio.ImageIO;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.jetbrains.annotations.NotNull;
 import org.telegram.telegrambots.meta.api.methods.ActionType;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageText;
 import org.telegram.telegrambots.meta.api.objects.Update;
 
 public class TestBotHandler extends BotHandler {
@@ -54,10 +60,20 @@ public class TestBotHandler extends BotHandler {
 
         // Locale
         commands.registerBundle(new LocalizationBundle());
+
+        addMethodPreprocessor(SendMessage.PATH, m -> {
+            var sm = (SendMessage) m;
+            sm.disableWebPagePreview();
+        });
+
+        addMethodPreprocessor(EditMessageText.PATH, m -> {
+            var emt = (EditMessageText) m;
+            emt.disableWebPagePreview();
+        });
     }
 
     @Override
-    public BotApiMethod onUpdate(Update update) {
+    public BotApiMethod<?> onUpdate(@NotNull Update update) {
         if (commands.handleUpdate(update)) {
             return null;
         }


### PR DESCRIPTION
Context:
Arguments methods moved to context from MessageContext/CallbackQueryContext
Removed unnecessary fields from Context  subclasses
Changed constructor access to public in Context subclasses
Fix: since "".split("\s+") returns { "" }, argumentsLength = 1 but it's actually 0.
Added method preprocessors to CommonAbsSender (also added examples)
