### PR TITLE
Remove circular dependency between BotHandler and CommandRegistry

### DIFF
--- a/module/src/main/java/com/annimon/tgbotsmodule/analytics/UpdateHandler.java
+++ b/module/src/main/java/com/annimon/tgbotsmodule/analytics/UpdateHandler.java
@@ -1,5 +1,6 @@
 package com.annimon.tgbotsmodule.analytics;
 
+import com.annimon.tgbotsmodule.BotHandler;
 import org.jetbrains.annotations.NotNull;
 import org.telegram.telegrambots.meta.api.objects.Update;
 
@@ -11,5 +12,5 @@ public interface UpdateHandler {
      * @param update  bot update
      * @return {@code true} if update was handled, {@code false} otherwise
      */
-    boolean handleUpdate(@NotNull Update update);
+    boolean handleUpdate(@NotNull Update update, BotHandler handler);
 }

--- a/module/src/main/java/com/annimon/tgbotsmodule/commands/CommandRegistry.java
+++ b/module/src/main/java/com/annimon/tgbotsmodule/commands/CommandRegistry.java
@@ -32,7 +32,7 @@ public class CommandRegistry<TRole extends Enum<TRole>> implements UpdateHandler
 
     private String callbackCommandSplitPattern;
 
-    public CommandRegistry(@NotNull String botUsername,@NotNull Authority<TRole> authority) {
+    public CommandRegistry(@NotNull String botUsername, @NotNull Authority<TRole> authority) {
         this.authority = authority;
         this.botUsername = "@" + botUsername.toLowerCase(Locale.ENGLISH);
         textCommands = ArrayListMultimap.create();

--- a/testbot-kotlin/src/main/kotlin/com/annimon/testbotkt/TestBotHandler.kt
+++ b/testbot-kotlin/src/main/kotlin/com/annimon/testbotkt/TestBotHandler.kt
@@ -17,7 +17,7 @@ import org.telegram.telegrambots.meta.api.objects.Update
 
 class TestBotHandler(private val botConfig: BotConfig) : BotHandler(botConfig.token) {
     private val authority = SimpleAuthority(this, botConfig.creatorId)
-    private val commands = CommandRegistry(this, authority)
+    private val commands = CommandRegistry(botUsername, authority)
 
     init {
         commands.register(SimpleCommand("/action", For.CREATOR) { ctx ->
@@ -64,7 +64,7 @@ class TestBotHandler(private val botConfig: BotConfig) : BotHandler(botConfig.to
     }
 
     override fun onUpdate(update: Update): BotApiMethod<*>? {
-        if (commands.handleUpdate(update)) {
+        if (commands.handleUpdate(update, this)) {
             return null
         }
         // handle other updates

--- a/testbot/src/main/java/com/annimon/testbot/TestBotHandler.java
+++ b/testbot/src/main/java/com/annimon/testbot/TestBotHandler.java
@@ -34,7 +34,7 @@ public class TestBotHandler extends BotHandler {
         this.botConfig = botConfig;
 
         final var authority = new SimpleAuthority(this, botConfig.getCreatorId());
-        commands = new CommandRegistry<>(this, authority);
+        commands = new CommandRegistry<>(getBotUsername(), authority);
 
         commands.register(new SimpleCommand("/action", For.CREATOR, ctx -> {
             if (ctx.argumentsLength() != 1) return;
@@ -67,7 +67,7 @@ public class TestBotHandler extends BotHandler {
 
     @Override
     public BotApiMethod<?> onUpdate(@NotNull Update update) {
-        if (commands.handleUpdate(update)) {
+        if (commands.handleUpdate(update, this)) {
             return null;
         }
         // handle other updates


### PR DESCRIPTION
When using DI frameworks like Spring or Micronaut, you will face circular dependency between BotHandler and CommandRegistry.
It happens because the constructor of CommandRegistry accepts BotHandler, but in order to send update from BotHandler to the CommandRegistry, you need to inject CommandRegistry to BotHandler.

Also, since CommandRegistry simply passess updates (wrapped with MessageContext/CallbackQueryContext which already contains BotHandler), and commands don't need to inject BotHandler, CommandRegistry also doesn't need to inject it.

This pull request breaks circular dependency and makes it easier to use this library along with DI frameworks