### PR TITLE
[commands] fix not matching entire region

### DIFF
--- a/module/src/main/java/com/annimon/tgbotsmodule/commands/CommandRegistry.java
+++ b/module/src/main/java/com/annimon/tgbotsmodule/commands/CommandRegistry.java
@@ -158,7 +158,7 @@ public class CommandRegistry<TRole extends Enum<TRole>> implements UpdateHandler
         final var text = message.getText();
         final long count = regexCommands.stream()
                 .map(cmd -> Map.entry(cmd, cmd.pattern().matcher(text)))
-                .filter(e -> e.getValue().find())
+                .filter(e -> e.getValue().matches())
                 .filter(e -> authority.hasRights(sender, update, message.getFrom(), e.getKey().authority()))
                 .peek(e -> {
                     final RegexCommand command = e.getKey();


### PR DESCRIPTION
- Fixed an issue where the com.annimon.tgbotsmodule.commands.RegexCommand's pattern didn't match the entire region, and when you e.g. set the pattern to `(\\d|[a-fA-F]){4,16}"`, it will trigger the command on message `1 4 75 9 3F2AB E`, but the bot developer might not expect it.